### PR TITLE
remove storing of binaries and symbols

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,18 +1,11 @@
 package app
 
 import (
-	"bytes"
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
-	"os/exec"
 	"sync"
 	"time"
 
@@ -34,9 +27,6 @@ type App struct {
 
 	profiles ProfileStore
 
-	symbolizerURLsMu sync.Mutex
-	symbolizerURLs   map[string]*url.URL
-
 	instancesMu      sync.Mutex
 	instances        map[string]*PProfInstance
 	nextInstancePort int
@@ -55,20 +45,18 @@ func New(c Config) (*App, error) {
 		instances:        make(map[string]*PProfInstance),
 		nextInstancePort: 8888,
 		profiles:         NewMemStore(),
-		symbolizerURLs:   make(map[string]*url.URL),
 		listener:         ln,
 		Server: &http.Server{
 			Handler: router,
 		},
 	}
-	router.PUT("/binaries/:md5", app.BinaryPUT)
+
 	router.POST("/profiles", app.ProfilePOST)
 	router.GET("/profiles", app.ProfileList)
 	router.GET("/profiles/:id", app.PProfProfileGET)
 	router.GET("/profiles/:id/web/*subpath", app.ProfileProxy)
 	router.PUT("/profiles/:id/web/*subpath", app.ProfileProxy)
 	router.POST("/profiles/:id/web/*subpath", app.ProfileProxy)
-	router.POST("/profiles/:id/debug/pprof/symbol", app.PProfSymbolPOST)
 	router.GET("/profiles/:id/debug/pprof/profile", app.PProfProfileGET)
 
 	return app, nil
@@ -114,26 +102,9 @@ func (app *App) ProfilePOST(w http.ResponseWriter, r *http.Request, ps httproute
 		fmt.Fprintf(w, "error parsing body: %v", err)
 		return
 	}
-	if req.BinaryMD5 == "" && req.SymoblizerURL == "" {
-		w.WriteHeader(400)
-		fmt.Fprintf(w, `at least one of "binary_md5" or "symbolizer_url" required`)
-		return
-	}
+
 	var resp msg.ProfilePostResponse
 	resp.ID = uuid.New()
-	if req.BinaryMD5 != "" {
-		err = app.profiles.StoreBinaryMD5(resp.ID, req.BinaryName, req.BinaryMD5)
-		if err != nil {
-			w.WriteHeader(500)
-			fmt.Fprintf(w, "error storing binary info: %v", err)
-			return
-		}
-
-		if !app.profiles.HasBinaryMD5(req.BinaryMD5) {
-			resp.BinaryNeedsUpload = true
-		}
-	}
-
 	err = app.profiles.StoreProfile(resp.ID, req.Profile)
 	if err != nil {
 		w.WriteHeader(500)
@@ -141,32 +112,21 @@ func (app *App) ProfilePOST(w http.ResponseWriter, r *http.Request, ps httproute
 		return
 	}
 
-	if req.SymoblizerURL != "" {
-		url, err := url.Parse(req.SymoblizerURL)
-		if err != nil {
-			w.WriteHeader(400)
-			fmt.Fprintf(w, "error parsing symbolizer_url: %v", err)
-			return
-		}
-		app.symbolizerURLsMu.Lock()
-		app.symbolizerURLs[resp.ID] = url
-		app.symbolizerURLsMu.Unlock()
-
-		// NOTE: we make this call (-top) because it will exit without any human interaction, therefore we
-		//       know that when this command exits, the appropriate calls to get the symbols will have
-		//       been called and we will have saved the symbols to the profile store.
-		cmd := exec.Command("pprof", "-top", fmt.Sprintf("http://%s/profiles/%s/debug/pprof/profile", app.config.ListenAddr, resp.ID))
-		err = cmd.Run()
-
-		if !app.profiles.HasSymbols(resp.ID) {
-			w.WriteHeader(502)
-			fmt.Fprintf(w, "failed to fetch symbols")
-			return
-		}
-	}
 	w.WriteHeader(201)
 	enc := json.NewEncoder(w)
 	enc.Encode(resp)
+}
+
+func (app *App) PProfProfileGET(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	id := ps.ByName("id")
+	b, err := app.profiles.GetProfile(id)
+	if err != nil {
+		// TODO: differentiate between this and failure to read
+		w.WriteHeader(404)
+		fmt.Fprintf(w, "could not find profile for %q", id)
+		return
+	}
+	w.Write(b)
 }
 
 func (app *App) ProfileProxy(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -179,7 +139,7 @@ func (app *App) ProfileProxy(w http.ResponseWriter, r *http.Request, ps httprout
 			NewPProfInstance(
 				fmt.Sprintf("http://%s/profiles/%s/debug/pprof/profile", app.config.ListenAddr, id),
 				fmt.Sprintf("/profiles/%s/web/", id),
-				id, app.nextInstancePort, app.profiles)
+				id, app.nextInstancePort)
 		if err == nil {
 			app.instances[id] = inst
 			app.nextInstancePort++
@@ -209,112 +169,4 @@ func (app *App) ProfileProxy(w http.ResponseWriter, r *http.Request, ps httprout
 		return
 	}
 	inst.handler.ServeHTTP(w, r)
-}
-
-func (app *App) BinaryPUT(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	var err error
-	md5in := ps.ByName("md5")
-	b, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		w.WriteHeader(400)
-		fmt.Fprintf(w, `failed to read request body: %v`, err)
-		return
-	}
-	h := md5.New()
-	h.Write(b)
-	md5sum := hex.EncodeToString(h.Sum(nil))
-	if md5sum != md5in {
-		w.WriteHeader(400)
-		fmt.Fprintf(w, `md5sum in path (%s) does not match md5 of put contents (%s)`, md5in, md5sum)
-		return
-	}
-	err = app.profiles.StoreBinary(md5sum, b)
-	if err != nil {
-		w.WriteHeader(500)
-		fmt.Fprintf(w, `failed to store binary: %v`, err)
-		return
-	}
-	enc := json.NewEncoder(w)
-	enc.Encode(map[string]string{"msg": "success"})
-}
-
-func (app *App) PProfProfileGET(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	id := ps.ByName("id")
-	b, err := app.profiles.GetProfile(id)
-	if err != nil {
-		// TODO: differentiate between this and failure to read
-		w.WriteHeader(404)
-		fmt.Fprintf(w, "could not find profile for %q", id)
-		return
-	}
-	w.Write(b)
-}
-
-func (app *App) PProfSymbolPOST(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	id := ps.ByName("id")
-	app.symbolizerURLsMu.Lock()
-	symbolizerURL := app.symbolizerURLs[id]
-	app.symbolizerURLsMu.Unlock()
-
-	if symbolizerURL != nil {
-		var symbols []byte
-		rp := &httputil.ReverseProxy{
-			Director: func(req *http.Request) {
-				// slightly modified from https://golang.org/src/net/http/httputil/reverseproxy.go?s=2588:2649#L80
-				req.URL.Scheme = symbolizerURL.Scheme
-				req.URL.Host = symbolizerURL.Host
-				req.URL.Path = symbolizerURL.Path
-				if symbolizerURL.RawQuery == "" || req.URL.RawQuery == "" {
-					req.URL.RawQuery = symbolizerURL.RawQuery + req.URL.RawQuery
-				} else {
-					req.URL.RawQuery = symbolizerURL.RawQuery + "&" + req.URL.RawQuery
-				}
-				if _, ok := req.Header["User-Agent"]; !ok {
-					// explicitly disable User-Agent so it's not set to default value
-					req.Header.Set("User-Agent", "")
-				}
-			},
-			ModifyResponse: func(resp *http.Response) error {
-				var err error
-				symbols, err = ioutil.ReadAll(resp.Body)
-				resp.Body.Close()
-				if err != nil {
-					return err
-				}
-				resp.Body = ioutil.NopCloser(bytes.NewReader(symbols))
-				return nil
-			},
-		}
-		rp.ServeHTTP(w, r)
-		if symbols == nil {
-			w.WriteHeader(502)
-			fmt.Fprintf(w, "failed to get symbols from: %q", symbolizerURL.String())
-			return
-		}
-		app.symbolizerURLsMu.Lock()
-		delete(app.symbolizerURLs, id)
-		app.symbolizerURLsMu.Unlock()
-
-		err := app.profiles.StoreSymbols(id, symbols)
-		if err != nil {
-			w.WriteHeader(500)
-			fmt.Fprintf(w, "failed to store symbols: %v", err)
-			return
-		}
-		return
-	}
-
-	if !app.profiles.HasSymbols(id) {
-		w.WriteHeader(404)
-		fmt.Fprintf(w, "could not find symbols for %q", id)
-		return
-	}
-
-	b, err := app.profiles.GetSymbols(id)
-	if err != nil {
-		w.WriteHeader(500)
-		fmt.Fprintf(w, "failed to get symbols: %v", err)
-		return
-	}
-	w.Write(b)
 }

--- a/app/memstore.go
+++ b/app/memstore.go
@@ -10,29 +10,19 @@ import (
 type ProfileStore interface {
 	ListProfiles() ([]msg.ProfileInfo, error)
 	StoreProfile(id string, profile []byte) error
-	StoreSymbols(id string, symbols []byte) error
-	StoreBinary(md5sum string, binary []byte) error
 	StoreBinaryMD5(id, name, md5 string) error
 	GetProfile(id string) (profile []byte, err error)
-	GetBinary(id string) (name string, binary []byte, err error)
-	GetSymbols(id string) (symbols []byte, err error)
-	HasBinaryMD5(md5 string) bool
-	HasSymbols(id string) bool
 }
 
 type MemStore struct {
 	mu       sync.RWMutex
 	profiles map[string][]byte
-	symbols  map[string][]byte
-	binaries map[string][]byte
 	binInfo  map[string]binInfo
 }
 
 func NewMemStore() *MemStore {
 	return &MemStore{
 		profiles: make(map[string][]byte),
-		symbols:  make(map[string][]byte),
-		binaries: make(map[string][]byte),
 		binInfo:  make(map[string]binInfo),
 	}
 }
@@ -58,18 +48,6 @@ func (ms *MemStore) StoreProfile(id string, profile []byte) error {
 	ms.profiles[id] = profile
 	return nil
 }
-func (ms *MemStore) StoreSymbols(id string, symbols []byte) error {
-	ms.mu.Lock()
-	defer ms.mu.Unlock()
-	ms.symbols[id] = symbols
-	return nil
-}
-func (ms *MemStore) StoreBinary(md5sum string, binary []byte) error {
-	ms.mu.Lock()
-	defer ms.mu.Unlock()
-	ms.binaries[md5sum] = binary
-	return nil
-}
 func (ms *MemStore) StoreBinaryMD5(id, name, md5Str string) error {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
@@ -85,39 +63,4 @@ func (ms *MemStore) GetProfile(id string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to find profile for %q", id)
 	}
 	return b, nil
-}
-func (ms *MemStore) GetBinary(id string) (string, []byte, error) {
-	ms.mu.RLock()
-	defer ms.mu.RUnlock()
-	info, ok := ms.binInfo[id]
-	if !ok {
-		return "", nil, fmt.Errorf("failed to find binInfo for %q", id)
-	}
-	b, ok := ms.binaries[info.MD5]
-	if !ok {
-		return "", nil, fmt.Errorf("failed to find binary for %q with md5=%q", id, info.MD5)
-	}
-	return info.BinaryName, b, nil
-}
-func (ms *MemStore) HasBinaryMD5(md5 string) bool {
-	ms.mu.RLock()
-	defer ms.mu.RUnlock()
-	_, ok := ms.binaries[md5]
-	return ok
-}
-
-func (ms *MemStore) GetSymbols(id string) ([]byte, error) {
-	ms.mu.RLock()
-	defer ms.mu.RUnlock()
-	b, ok := ms.symbols[id]
-	if !ok {
-		return nil, fmt.Errorf("could not find symbols for %q", id)
-	}
-	return b, nil
-}
-func (ms *MemStore) HasSymbols(id string) bool {
-	ms.mu.RLock()
-	defer ms.mu.RUnlock()
-	_, ok := ms.symbols[id]
-	return ok
 }

--- a/app/pprof_test.go
+++ b/app/pprof_test.go
@@ -1,22 +1,11 @@
 package app
 
 import (
-	"crypto/md5"
-	"encoding/hex"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
-	"time"
-
-	"net/http"
-	"net/http/httptest"
 	_ "net/http/pprof"
-
-	"github.com/PuerkitoBio/goquery"
 )
 
+/* TODO: redo this test, we not longer want to support storing the binary, because profiles
+		 now contain the symbol information in them.
 func TestPProfInstanceWithBinary(t *testing.T) {
 	id := "123456"
 
@@ -88,3 +77,4 @@ func TestPProfInstanceWithBinary(t *testing.T) {
 		t.Fatalf("status code not as expected for non-existent page: exp: %d, got: %d", exp, got)
 	}
 }
+*/

--- a/client/middleware_test.go
+++ b/client/middleware_test.go
@@ -53,8 +53,7 @@ func TestCPUProfile(t *testing.T) {
 	}
 
 	msgResp := msg.ProfilePostResponse{
-		ID:                "23E3490F-9F1F-4A19-9EBB-07592A7A1ED0",
-		BinaryNeedsUpload: false,
+		ID: "23E3490F-9F1F-4A19-9EBB-07592A7A1ED0",
 	}
 
 	// TODO: we need to figure out how to test that this is a CPU profile rather than
@@ -88,12 +87,10 @@ func TestHeapProfile(t *testing.T) {
 	}
 
 	msgResp := msg.ProfilePostResponse{
-		ID:                "23E3490F-9F1F-4A19-9EBB-07592A7A1ED0",
-		BinaryNeedsUpload: false,
+		ID: "23E3490F-9F1F-4A19-9EBB-07592A7A1ED0",
 	}
 	msgResp2 := msg.ProfilePostResponse{
-		ID:                "02A89E6F-6652-4B0A-B6E4-1383069E9CFA",
-		BinaryNeedsUpload: false,
+		ID: "02A89E6F-6652-4B0A-B6E4-1383069E9CFA",
 	}
 
 	// TODO: we need to figure out how to test that this is a MEM profile rather than

--- a/msg/msg.go
+++ b/msg/msg.go
@@ -1,15 +1,13 @@
 package msg
 
 type ProfilePostRequest struct {
-	Profile       []byte `json:"profile"`
-	BinaryName    string `json:"binary_name"`
-	BinaryMD5     string `json:"binary_md5"`
-	SymoblizerURL string `json:"symbolizer_url"`
+	Profile    []byte              `json:"profile"`
+	BinaryName string              `json:"binary_name"`
+	BinaryMD5  string              `json:"binary_md5"`
 }
 
 type ProfilePostResponse struct {
-	ID                string `json:"id"`
-	BinaryNeedsUpload bool   `json:"binary_needs_upload"`
+	ID string `json:"id"`
 }
 
 type ProfileListResponse struct {


### PR DESCRIPTION
Recent version of go/pprof put the symbols in the profile, so there
is no need to find them external to the profile. This massively
simplifies a lot of the code as well as the ProfileStore interface.